### PR TITLE
Fix content formatting errors in web files

### DIFF
--- a/_includes/giscus.liquid
+++ b/_includes/giscus.liquid
@@ -25,8 +25,9 @@
     </script>
     <noscript>Please enable JavaScript to view the <a href="http://giscus.app/?ref_noscript">comments powered by giscus.</a></noscript>
   {% else %}
-    {% capture giscus_warning %} > ##### giscus comments misconfigured > Please follow instructions at
-  [http://giscus.app](http://giscus.app) and update your giscus configuration. {: .block-danger } {% endcapture %}
-    {{ giscus_warning | markdownify }}
+    <div class="alert alert-danger" role="alert">
+      <h5 class="alert-heading">giscus comments misconfigured</h5>
+      <p>Please follow instructions at <a href="http://giscus.app" target="_blank">http://giscus.app</a> and update your giscus configuration.</p>
+    </div>
   {% endif %}
 </div>


### PR DESCRIPTION
Convert Giscus configuration warning in `_includes/giscus.liquid` from markdown to direct HTML to ensure correct display.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddd2b0b6-cb76-44a8-b0b3-92e455d931fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddd2b0b6-cb76-44a8-b0b3-92e455d931fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

